### PR TITLE
Set support

### DIFF
--- a/PrintNodeComputer.cs
+++ b/PrintNodeComputer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using PrintNodeNet.Http;
+using PrintNodeNet.Util;
 
 namespace PrintNodeNet
 {
@@ -49,12 +50,76 @@ namespace PrintNodeNet
             return list.FirstOrDefault();
         }
 
+        /// <summary>
+        /// Static method to retrieve a set of computers from the PrintNode API.
+        /// </summary>
+        /// <param name="computerSet">The list of ids of the computers.</param>
+        /// <param name="options">The request options (allows API key modification)</param>
+        /// <returns>The list of <seealso cref="PrintNodeComputer"/> matching to the given ids</returns>
+        public static async Task<IEnumerable<PrintNodeComputer>> GetSetAsync(IEnumerable<long> computerSet, PrintNodeRequestOptions options = null)
+        {
+            string ids = new SetBuilder(computerSet).Build();
+
+            var response = await PrintNodeApiHelper.Get($"/computers/{ids}", options);
+
+            return JsonConvert.DeserializeObject<List<PrintNodeComputer>>(response);
+        }
+
         public async Task<IEnumerable<PrintNodePrinter>> ListPrinters(PrintNodeRequestOptions options = null)
         {
             var response = await PrintNodeApiHelper.Get($"/computers/{Id}/printers", options);
 
             return JsonConvert.DeserializeObject<List<PrintNodePrinter>>(response);
 
+        }
+
+        /// <summary>
+        /// Static overwrite of the <seealso cref="ListPrinters(PrintNodeRequestOptions)"/> method
+        /// to get the printers of the given computer.
+        /// </summary>
+        /// <param name="id">The id of the computer to get the printers from.</param>
+        /// <param name="options">The request options (allows API key modification)</param>
+        /// <returns>The list of <seealso cref="PrintNodePrinter"/> that belongs to the given computer</returns>
+        public static async Task<IEnumerable<PrintNodePrinter>> ListPrinters(long id, PrintNodeRequestOptions options = null)
+        {
+            var response = await PrintNodeApiHelper.Get($"/computers/{id}/printers", options);
+
+            return JsonConvert.DeserializeObject<List<PrintNodePrinter>>(response);
+
+        }
+
+        /// <summary>
+        /// Static method to retrieve the list of <seealso cref="PrintNodePrinter"/> that belongs
+        /// to the given set of computers.
+        /// </summary>
+        /// <param name="computerSet">The list of ids of the computers.</param>
+        /// <param name="options">The request options (allows API key modification).</param>
+        /// <returns>The list of <seealso cref="PrintNodePrinter"/> that belongs to the given set of computers.</returns>
+        public static async Task<IEnumerable<PrintNodePrinter>> ListComputerSetPrintersAsync(IEnumerable<long> computerSet, PrintNodeRequestOptions options = null)
+        {
+            string ids = new SetBuilder(computerSet).Build();
+
+            var response = await PrintNodeApiHelper.Get($"/computers/{ids}/printers", options);
+
+            return JsonConvert.DeserializeObject<List<PrintNodePrinter>>(response);
+        }
+
+        /// <summary>
+        /// Static method to retrieve the given set of <seealso cref="PrintNodePrinter"/> if they
+        /// belong to the given set of computers.
+        /// </summary>
+        /// <param name="computerSet">The list of ids of the computers.</param>
+        /// <param name="printerSet">The list of ids of the printers.</param>
+        /// <param name="options">The request options (allows API key modification).</param>
+        /// <returns>The set of <seealso cref="PrintNodePrinter"/> that belongs to the given set of computers.</returns>
+        public static async Task<IEnumerable<PrintNodePrinter>> ListComputerSetPrinterSetAsync(IEnumerable<long> computerSet, IEnumerable<long> printerSet, PrintNodeRequestOptions options = null)
+        {
+            string computerIds = new SetBuilder(computerSet).Build();
+            string printerIds = new SetBuilder(printerSet).Build();
+
+            var response = await PrintNodeApiHelper.Get($"/computers/{computerIds}/printers/{printerIds}", options);
+
+            return JsonConvert.DeserializeObject<List<PrintNodePrinter>>(response);
         }
     }
 }

--- a/PrintNodePrintJob.cs
+++ b/PrintNodePrintJob.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using PrintNodeNet.Http;
+using PrintNodeNet.Util;
 
 namespace PrintNodeNet
 {
@@ -132,6 +133,40 @@ namespace PrintNodeNet
             return JsonConvert.DeserializeObject<IEnumerable<PrintNodePrintJob>>(response);
         }
 
+        /// <summary>
+        /// Static method that allows the retrieval of the list of <seealso cref="PrintNodePrintJob"/>
+        /// for a set of <seealso cref="PrintNodePrinter"/>.
+        /// </summary>
+        /// <param name="set">The ids of the printers</param>
+        /// <param name="options">The request options (allows API key modification).</param>
+        /// <returns>The print jobs of every printer that has its ID included in the set</returns>
+        public static async Task<IEnumerable<PrintNodePrintJob>> ListForPrinterSetAsync(IEnumerable<long> set, PrintNodeRequestOptions options = null)
+        {
+            string ids = new SetBuilder(set).Build();
+
+            var response = await PrintNodeApiHelper.Get($"/printers/{ids}/printjobs", options);
+
+            return JsonConvert.DeserializeObject<IEnumerable<PrintNodePrintJob>>(response);
+        }
+
+        /// <summary>
+        /// Static method that allows the retrieval of a set of <seealso cref="PrintNodePrintJob"/>
+        /// for a set of <seealso cref="PrintNodePrinter"/>.
+        /// </summary>
+        /// <param name="printerSet">The ids of the printers</param>
+        /// <param name="printjobSet">The ids of the print jobs</param>
+        /// <param name="options">The request options (allows API key modification).</param>
+        /// <returns>The union between print jobs of the given ids and printjobs of the given printers.</returns>
+        public static async Task<IEnumerable<PrintNodePrintJob>> ListPrinjobSetForPrinterSetAsync(IEnumerable<long> printerSet, IEnumerable<long> printjobSet, PrintNodeRequestOptions options = null)
+        {
+            string printerIds = new SetBuilder(printerSet).Build();
+            string printjobsIds = new SetBuilder(printjobSet).Build();
+
+            var response = await PrintNodeApiHelper.Get($"/printers/{printerIds}/printjobs/{printjobsIds}", options);
+
+            return JsonConvert.DeserializeObject<IEnumerable<PrintNodePrintJob>>(response);
+        }
+
         public static async Task<PrintNodePrintJob> GetAsync(long id, PrintNodeRequestOptions options = null)
         {
             var response = await PrintNodeApiHelper.Get($"/printjobs/{id}", options);
@@ -141,6 +176,22 @@ namespace PrintNodeNet
             return list.FirstOrDefault();
         }
 
+        /// <summary>
+        /// Static method that allows the retrieval of a set of <seealso cref="PrintNodePrintJob"/>,
+        /// identified by their IDs.
+        /// </summary>
+        /// <param name="set">The ids of the print jobs</param>
+        /// <param name="options">The request options (allows API key modification).</param>
+        /// <returns>The print jobs as an enumerable.</returns>
+        public static async Task<IEnumerable<PrintNodePrintJob>> GetSetAsync(IEnumerable<long> set, PrintNodeRequestOptions options = null)
+        {
+            string ids = new SetBuilder(set).Build();
+
+            var response = await PrintNodeApiHelper.Get($"/printjobs/{ids}", options);
+
+            return JsonConvert.DeserializeObject<IEnumerable<PrintNodePrintJob>>(response);
+        }
+
         public async Task<IEnumerable<PrintNodePrintJobState>> GetStates(PrintNodeRequestOptions options = null)
         {
             var response = await PrintNodeApiHelper.Get($"/printjobs/{Id}/states", options);
@@ -148,6 +199,37 @@ namespace PrintNodeNet
             var list = JsonConvert.DeserializeObject<IEnumerable<IEnumerable<PrintNodePrintJobState>>>(response);
 
             return list.FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Static overwrite of the <seealso cref="GetStates(PrintNodeRequestOptions)"/> method.
+        /// It retrieves all the history of states for the given printjob id.
+        /// </summary>
+        /// <param name="id">The print job ID to get the history from.</param>
+        /// <param name="options">The request options (allows API key modification).</param>
+        /// <returns>A list of <seealso cref="PrintNodePrintJobState"/> that traces every state the printjob has been in since its creation.</returns>
+        public static async Task<IEnumerable<PrintNodePrintJobState>> GetStates(long id, PrintNodeRequestOptions options = null)
+        {
+            var response = await PrintNodeApiHelper.Get($"/printjobs/{id}/states", options);
+
+            var list = JsonConvert.DeserializeObject<IEnumerable<IEnumerable<PrintNodePrintJobState>>>(response);
+
+            return list.FirstOrDefault();
+        }
+
+        /// <summary>
+        /// This method retrieves all the history of states for the given set of print jobs.
+        /// </summary>
+        /// <param name="set">The ids of all the print jobs we want to get the states of.</param>
+        /// <param name="options">The request options (allows API key modification).</param>
+        /// <returns>A list of <seealso cref="PrintNodePrintJobState"/> that traces every state the print job has been in since its creation, for every print job of the set.</returns>
+        public static async Task<IEnumerable<IEnumerable<PrintNodePrintJobState>>> GetPrintJobSetStatesAsync(IEnumerable<long> set, PrintNodeRequestOptions options = null)
+        {
+            string ids = new SetBuilder(set).Build();
+
+            var response = await PrintNodeApiHelper.Get($"/printjobs/{ids}/states", options);
+
+            return JsonConvert.DeserializeObject<IEnumerable<IEnumerable<PrintNodePrintJobState>>>(response);
         }
 
 		 public async Task<long> Print(PrintNodeRequestOptions options = null)

--- a/PrintNodePrinter.cs
+++ b/PrintNodePrinter.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using PrintNodeNet.Http;
+using PrintNodeNet.Util;
 
 namespace PrintNodeNet
 {
@@ -47,6 +48,21 @@ namespace PrintNodeNet
             var list = JsonConvert.DeserializeObject<List<PrintNodePrinter>>(response);
 
             return list.FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Static method to retrieve a set of printers from the PrintNode API.
+        /// </summary>
+        /// <param name="printerSet">The list of ids of the printers.</param>
+        /// <param name="options">The request options (allows API key modification).</param>
+        /// <returns>The list of <seealso cref="PrintNodePrinter"/> matching to the given ids.</returns>
+        public static async Task<IEnumerable<PrintNodePrinter>> GetSetAsync(IEnumerable<long> printerSet, PrintNodeRequestOptions options = null)
+        {
+            string ids = new SetBuilder(printerSet).Build();
+
+            var response = await PrintNodeApiHelper.Get($"/printers/{ids}", options);
+
+            return JsonConvert.DeserializeObject<List<PrintNodePrinter>>(response);
         }
 
         public async Task<long> AddPrintJob(PrintNodePrintJob job, PrintNodeRequestOptions options = null)

--- a/Util/SetBuilder.cs
+++ b/Util/SetBuilder.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Text;
+
+namespace PrintNodeNet.Util
+{
+    /// <summary>
+    /// The SetBuilder class is a tool that helps mutualising the code for generating sets of any
+    /// kind.
+    /// To get the set as a string, use the Build method.
+    /// </summary>
+    public class SetBuilder
+    {
+        private StringBuilder Set;
+        public int Size { get; private set; }
+
+        /// <summary>
+        /// This parameterless constructor simply instanciates a new StringBuilder and sets the
+        /// Size to 0. Use the Add method to then add content to the set.
+        /// </summary>
+        public SetBuilder()
+        {
+            Set = new StringBuilder();
+            Size = 0;
+        }
+
+        /// <summary>
+        /// This constructor creates a new instance of SetBuilder with an Enumerable of longs as
+        /// template.
+        /// </summary>
+        /// <param name="set">The set of ids to add to the new SetBuilder</param>
+        public SetBuilder(IEnumerable<long> set)
+        {
+            Size = 0;
+            Set = new StringBuilder();
+            foreach (long item in set)
+            {
+                Set.Append(item);
+                Set.Append(',');
+                Size++;
+            }
+        }
+
+        /// <summary>
+        /// This method allows the addition of extra elements to the set if needed.
+        /// </summary>
+        /// <param name="set">The set of ids to add to the new SetBuilder</param>
+        public void Add(IEnumerable<long> set)
+        {
+            foreach (long item in set)
+            {
+                Set.Append(item);
+                Set.Append(',');
+                Size++;
+            }
+        }
+
+        /// <summary>
+        /// The Build method returns the string built from the StringBuilder that has been edited
+        /// throughout the SetBuilder lifetime.
+        /// </summary>
+        /// <returns>The set as a string, ready for querying the PrintNode API.</returns>
+        public string Build()
+        {
+            if (Size > 0)
+            {
+                //We remove the last comma from the set
+                Set.Remove(Set.Length -1, 1);
+            }
+
+            return Set.ToString();
+        }
+    }
+}


### PR DESCRIPTION
I added the set support as I mentioned in [my issue](https://github.com/christianz/printnode-net/issues/15).

To make things more simple, I added a Util subdirectory to the project. It contains the SetBuilder class, which is general to any kind of set (computers, printers, printjobs, ...) and helps turning the IEnumerable objects into strings sets that conforms to the PrintNode API standards. It uses a StringBuilder for optimization concerns.

Each method added has successfully been tested (including SetBuilder's ones) with MSTest. I can also provide the test classes if necessary. I'm not too sure about naming conventions though, and the documentation might not be perfect as well.

Looking forward to hearing from you!