### PR TITLE
Used long for PrintNodeScale.Mass

### DIFF
--- a/PrintNodeScale.cs
+++ b/PrintNodeScale.cs
@@ -19,7 +19,7 @@ namespace PrintNodeNet
         /// For example, a reading of 125g with a resolution of 5g would be represented as [125000000, 5000000].
         /// </summary>
         [JsonProperty("mass")]
-        public int?[] Mass { get; set; }
+        public long?[] Mass { get; set; }
 
         /// <summary>
         /// A string identifier for the scale. This is usually the scale's manufacturer and description, unless it has been renamed

--- a/README.md
+++ b/README.md
@@ -135,4 +135,6 @@ var computerId = 12777;
 var deviceName = "Fairbanks Scales - Fairbanks Scales SCB-R9000";
 var deviceNum = 0;
 var scale = await PrintNodeScale.GetAsync(computerId, deviceName, deviceNum);
+
+var massInMicrograms = scale.Mass[0];
 ```

--- a/README.md
+++ b/README.md
@@ -115,3 +115,24 @@ using (new PrintNodeDelegatedClientContext(accountId))
 	var printers = PrintNodePrinter.ListAsync();
 }
 ```
+
+## To list scales for a specific computer
+```csharp
+var computerId = 12777;
+var scales = await PrintNodeScale.ListForComputerAsync(computerId);
+```
+
+## To list scales for a specific computer and scale name
+```csharp
+var computerId = 12777;
+var deviceName = "Fairbanks Scales - Fairbanks Scales SCB-R9000";
+var scales = await PrintNodeScale.ListForComputerDeviceAsync(computerId, deviceName);
+```
+
+## To get a specific scale
+```csharp
+var computerId = 12777;
+var deviceName = "Fairbanks Scales - Fairbanks Scales SCB-R9000";
+var deviceNum = 0;
+var scale = await PrintNodeScale.GetAsync(computerId, deviceName, deviceNum);
+```


### PR DESCRIPTION
Fixes deserialization for larger weights from scale, which are returned in micrograms.  Resolves errors like:
```JSON integer 7461588400 is too large or small for an Int32. Path 'mass[0]', line 1, position 322.```